### PR TITLE
made tabs actually work and correctly route back after confirmation

### DIFF
--- a/lib/home_page.dart
+++ b/lib/home_page.dart
@@ -44,6 +44,7 @@ class _HomePageState extends State<HomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: AppBar(title: const Text("Home"),),
       backgroundColor: Colors.blue.withOpacity(0.1),
       body: Column(children: [
          SizedBox(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,4 @@
+import "package:bitcoin_demo_app/buy_bitcoin.dart";
 import "package:bitcoin_demo_app/home_page.dart";
 import "package:flutter/material.dart";
 
@@ -26,14 +27,19 @@ class RootPage extends StatefulWidget {
 
 class _RootPageState extends State<RootPage> {
   int currentPage = 0;
+ 
+
+
   @override
   Widget build(BuildContext context) {
+    final List pages = [
+      HomePage(),
+      BuyBitcoinPage()
+    ];
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("Home"),
-      ),
-      body: const HomePage(),
+      body: pages[currentPage],
       bottomNavigationBar: NavigationBar(
+
           destinations: const [
             NavigationDestination(icon: Icon(Icons.home), label: "Home"),
             NavigationDestination(
@@ -42,7 +48,9 @@ class _RootPageState extends State<RootPage> {
           onDestinationSelected: (int index) {
             setState(() {
               currentPage = index;
+              
             });
+            
           },
           selectedIndex: currentPage),
     );


### PR DESCRIPTION
Made tabs actually work and correctly route back after confirmation. The done button on the confirmation was routing back to the first page in routes or the home page but caused unexpected behavior with the ui. adding the tab pages to the root page, and then setting the done button to route to the root page solved the problem.